### PR TITLE
Feature/crud categorias

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,10 +39,22 @@ model User {
   uid String @id @default(uuid())
 
   idUserAd String @unique @map("id_user_ad")
-  name     String
+  name     String 
   email    String @unique
 
   enable Boolean @default(true)
 
   @@map("user")
+}
+
+model Categories {
+  uid String @id @default(uuid())
+
+  name String @db.VarChar(50)
+  enable Boolean @default(true)
+
+  createdAt DateTime @default(now()) @map("create_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("update_at")
+  
+  @@map("categories")
 }

--- a/requests/categories/createCategory.http
+++ b/requests/categories/createCategory.http
@@ -1,0 +1,12 @@
+@HOST = http://localhost:8080/api
+
+POST {{HOST}}/categories HTTP/1.1
+Content-Type: application/json
+
+# Campos obrigatórios: todos
+
+{
+    "name": "papelaria",
+    "enable": true
+}
+

--- a/requests/categories/findAllCategories.http
+++ b/requests/categories/findAllCategories.http
@@ -1,0 +1,4 @@
+@HOST = http://localhost:8080/api
+
+GET {{HOST}}/categories HTTP/1.1
+Content-Type: application/json

--- a/requests/categories/updateCategory.http
+++ b/requests/categories/updateCategory.http
@@ -1,0 +1,12 @@
+@HOST = http://localhost:8080/api
+
+PUT  {{HOST}}/categories/9b153362-bc60-4669-b9dc-42718c0e0a0e HTTP/1.1
+Content-Type: application/json
+
+# Campos obrigatórios: todos
+
+{
+    "name": "escritório update",
+    "enable": false
+}
+

--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -12,10 +12,12 @@ import { ConfigService } from '@nestjs/config';
 
 const makeCategoriesDTO = (): CategoriesDTO => {
   return {
-    name: 'Test Category',
+    name: 'Eletrônicos',
     enable: true
   };
 };
+
+const uid = 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11';
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
@@ -41,8 +43,8 @@ describe('CategoriesController', () => {
 
       jest.spyOn(service, 'create').mockImplementation(async () => {
         return Promise.resolve({
-          uid: '1',
-          name: 'Test Category',
+          uid: 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11',
+          name: 'Eletrônicos',
           enable: true,
         });
       });
@@ -50,7 +52,7 @@ describe('CategoriesController', () => {
       const result = await controller.create(categoryDTO);
 
       expect(result).toBeDefined();
-      expect(result.uid).toEqual('1');
+      expect(result.uid).toEqual('fcca0cf5-4e29-41e1-83ec-ce14fa973b11');
     });
 
     it('should handle duplicate category and return BadRequestException on failure', async () => {
@@ -87,8 +89,8 @@ describe('CategoriesController', () => {
   describe('FindAll - GET', () => {
     it('should get all categories on success', async () => {
       const categoriesData = [
-        { uid: '1', name: 'Category 1', enable: true },
-        { uid: '2', name: 'Category 2', enable: true },
+        { uid: 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11', name: 'Eletrônicos', enable: true },
+        { uid: '4f8f05a2-c694-4e7f-b972-4bad692e0ca5', name: 'Moda', enable: true },
       ];
 
       jest.spyOn(service, 'findAll').mockImplementation(async () => {
@@ -117,13 +119,12 @@ describe('CategoriesController', () => {
 
   describe('Update - PUT', () => {
     it('should update a category and return the updated data on success', async () => {
-      const uid = '1';
       const categoryDTO = makeCategoriesDTO();
 
       jest.spyOn(service, 'update').mockImplementation(async () => {
         return Promise.resolve({
-          uid: '1',
-          name: 'Updated Test Category',
+          uid: 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11',
+          name: 'Eletrônicos',
           enable: true,
         });
       });
@@ -131,12 +132,11 @@ describe('CategoriesController', () => {
       const result = await controller.update(uid, categoryDTO);
 
       expect(result).toBeDefined();
-      expect(result.uid).toEqual('1');
-      expect(result.name).toEqual('Updated Test Category');
+      expect(result.uid).toEqual('fcca0cf5-4e29-41e1-83ec-ce14fa973b11');
+      expect(result.name).toEqual('Eletrônicos');
     });
 
     it('should handle not found category and return NotFoundException on failure', async () => {
-      const uid = '1';
       const categoryDTO = makeCategoriesDTO();
 
       jest.spyOn(service, 'update').mockImplementation(async () => {
@@ -152,7 +152,6 @@ describe('CategoriesController', () => {
     });
 
     it('should handle errors and return InternalServerErrorException on failure', async () => {
-      const uid = '1';
       const categoryDTO = makeCategoriesDTO();
 
       jest.spyOn(service, 'update').mockImplementation(async () => {

--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -1,20 +1,170 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CategoriesController } from './categories.controller';
+import { CategoriesDTO } from './dto';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+
+const makeCategoriesDTO = (): CategoriesDTO => {
+  return {
+    name: 'Test Category',
+    enable: true
+  };
+};
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
+  let service: CategoriesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CategoriesController],
-      providers: [CategoriesService],
+      providers: [CategoriesService, PrismaService, ConfigService],
     }).compile();
 
     controller = module.get<CategoriesController>(CategoriesController);
+    service = module.get<CategoriesService>(CategoriesService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('Create - POST', () => {
+    it('should create a category and return the created data on success', async () => {
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'create').mockImplementation(async () => {
+        return Promise.resolve({
+          uid: '1',
+          name: 'Test Category',
+          enable: true,
+        });
+      });
+
+      const result = await controller.create(categoryDTO);
+
+      expect(result).toBeDefined();
+      expect(result.uid).toEqual('1');
+    });
+
+    it('should handle duplicate category and return BadRequestException on failure', async () => {
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'create').mockImplementation(async () => {
+        throw new BadRequestException('Essa categoria já existe.');
+      });
+
+      try {
+        await controller.create(categoryDTO);
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.message).toEqual('Essa categoria já existe.');
+      }
+    });
+
+    it('should handle errors and return InternalServerErrorException on failure', async () => {
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'create').mockImplementation(async () => {
+        throw new InternalServerErrorException('Test error');
+      });
+
+      try {
+        await controller.create(categoryDTO);
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toEqual('Test error');
+      }
+    });
+  });
+
+  describe('FindAll - GET', () => {
+    it('should get all categories on success', async () => {
+      const categoriesData = [
+        { uid: '1', name: 'Category 1', enable: true },
+        { uid: '2', name: 'Category 2', enable: true },
+      ];
+
+      jest.spyOn(service, 'findAll').mockImplementation(async () => {
+        return Promise.resolve(categoriesData);
+      });
+
+      const result = await controller.findAll();
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(categoriesData);
+    });
+
+    it('should handle errors and return InternalServerErrorException on failure', async () => {
+      jest.spyOn(service, 'findAll').mockImplementation(async () => {
+        throw new InternalServerErrorException('Test error');
+      });
+
+      try {
+        await controller.findAll();
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toEqual('Test error');
+      }
+    });
+  });
+
+  describe('Update - PUT', () => {
+    it('should update a category and return the updated data on success', async () => {
+      const uid = '1';
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'update').mockImplementation(async () => {
+        return Promise.resolve({
+          uid: '1',
+          name: 'Updated Test Category',
+          enable: true,
+        });
+      });
+
+      const result = await controller.update(uid, categoryDTO);
+
+      expect(result).toBeDefined();
+      expect(result.uid).toEqual('1');
+      expect(result.name).toEqual('Updated Test Category');
+    });
+
+    it('should handle not found category and return NotFoundException on failure', async () => {
+      const uid = '1';
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'update').mockImplementation(async () => {
+        throw new NotFoundException('Categoria não encontrada.');
+      });
+
+      try {
+        await controller.update(uid, categoryDTO);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+        expect(error.message).toEqual('Categoria não encontrada.');
+      }
+    });
+
+    it('should handle errors and return InternalServerErrorException on failure', async () => {
+      const uid = '1';
+      const categoryDTO = makeCategoriesDTO();
+
+      jest.spyOn(service, 'update').mockImplementation(async () => {
+        throw new InternalServerErrorException('Test error');
+      });
+
+      try {
+        await controller.update(uid, categoryDTO);
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toEqual('Test error');
+      }
+    });
   });
 });

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,15 +1,14 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Put } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
-import { CreateCategoryDto } from './dto/create-category.dto';
-import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoriesDTO } from './dto';
 
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Post()
-  create(@Body() createCategoryDto: CreateCategoryDto) {
-    return this.categoriesService.create(createCategoryDto);
+  create(@Body() categoryDto: CategoriesDTO) {
+    return this.categoriesService.create(categoryDto);
   }
 
   @Get()
@@ -17,18 +16,8 @@ export class CategoriesController {
     return this.categoriesService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.categoriesService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateCategoryDto: UpdateCategoryDto) {
-    return this.categoriesService.update(+id, updateCategoryDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.categoriesService.remove(+id);
+  @Put(':uid')
+  update(@Param('uid') uid: string, @Body() categoryDTO: CategoriesDTO) {
+    return this.categoriesService.update(uid, categoryDTO);
   }
 }

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -1,12 +1,40 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesService } from './categories.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { CategoriesDTO } from './dto';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+
+const uid = '1';
+
+const categoryDTO: CategoriesDTO = {
+  name: 'Test Category',
+  enable: true,
+};
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
 
+  // Mock PrismaService
+  const prismaServiceMock = {
+    categories: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoriesService],
+      providers: [
+        CategoriesService,
+        { provide: PrismaService, useValue: prismaServiceMock },
+      ],
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);
@@ -14,5 +42,69 @@ describe('CategoriesService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a category', async () => {
+      prismaServiceMock.categories.findFirst.mockResolvedValueOnce(null);
+
+      prismaServiceMock.categories.create.mockResolvedValueOnce(categoryDTO);
+
+      const result = await service.create(categoryDTO);
+
+      expect(result).toEqual(categoryDTO);
+    });
+
+    it('should throw BadRequestException if category already exists', async () => {
+      prismaServiceMock.categories.findFirst.mockResolvedValueOnce(categoryDTO);
+
+      await expect(service.create(categoryDTO)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of categories', async () => {
+      const mockCategories = [
+        { uid: '1', name: 'Category1', enable: true },
+        { uid: '2', name: 'Category2', enable: true },
+      ];
+      prismaServiceMock.categories.findMany.mockResolvedValueOnce(mockCategories);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual(mockCategories);
+    });
+
+    it('should throw InternalServerErrorException on error', async () => {
+      prismaServiceMock.categories.findMany.mockRejectedValueOnce(new Error('Mocked error'));
+
+      await expect(service.findAll()).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a category', async () => {
+      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Old Category', enable: false });
+
+      prismaServiceMock.categories.update.mockResolvedValueOnce({ uid, ...categoryDTO });
+
+      const result = await service.update(uid, categoryDTO);
+
+      expect(result).toEqual({ uid, ...categoryDTO });
+    });
+
+    it('should throw NotFoundException if category is not found', async () => {
+      prismaServiceMock.categories.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.update(uid, categoryDTO)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException on error', async () => {
+      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Old Category', enable: false });
+
+      prismaServiceMock.categories.update.mockRejectedValueOnce(new Error('Mocked error'));
+
+      await expect(service.update(uid, categoryDTO)).rejects.toThrow(InternalServerErrorException);
+    });
   });
 });

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -8,17 +8,16 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
-const uid = '1';
+const uid = 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11';
 
 const categoryDTO: CategoriesDTO = {
-  name: 'Test Category',
+  name: 'Eletrônicos',
   enable: true,
 };
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
 
-  // Mock PrismaService
   const prismaServiceMock = {
     categories: {
       findFirst: jest.fn(),
@@ -73,8 +72,8 @@ describe('CategoriesService', () => {
   describe('findAll', () => {
     it('should return an array of categories', async () => {
       const mockCategories = [
-        { uid: '1', name: 'Category1', enable: true },
-        { uid: '2', name: 'Category2', enable: true },
+        { uid: 'fcca0cf5-4e29-41e1-83ec-ce14fa973b11', name: 'Eletrônicos', enable: true },
+        { uid: '4f8f05a2-c694-4e7f-b972-4bad692e0ca5', name: 'Moda', enable: true },
       ];
       prismaServiceMock.categories.findMany.mockResolvedValueOnce(mockCategories);
 
@@ -92,7 +91,7 @@ describe('CategoriesService', () => {
 
   describe('update', () => {
     it('should update a category', async () => {
-      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Old Category', enable: false });
+      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Eletrônicos', enable: false });
 
       prismaServiceMock.categories.update.mockResolvedValueOnce({ uid, ...categoryDTO });
 
@@ -108,7 +107,7 @@ describe('CategoriesService', () => {
     });
 
     it('should throw InternalServerErrorException on error', async () => {
-      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Old Category', enable: false });
+      prismaServiceMock.categories.findUnique.mockResolvedValueOnce({ uid, name: 'Eletrônicos', enable: false });
 
       prismaServiceMock.categories.update.mockRejectedValueOnce(new Error('Mocked error'));
 

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -55,6 +55,14 @@ describe('CategoriesService', () => {
       expect(result).toEqual(categoryDTO);
     });
 
+    it('should throw InternalServerErrorException on error during category creation', async () => {
+      prismaServiceMock.categories.findFirst.mockRejectedValueOnce(
+        new InternalServerErrorException('Mocked error')
+      );
+
+      await expect(service.create(categoryDTO)).rejects.toThrow(InternalServerErrorException);
+    });
+
     it('should throw BadRequestException if category already exists', async () => {
       prismaServiceMock.categories.findFirst.mockResolvedValueOnce(categoryDTO);
 

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,12 +1,11 @@
 import {
   BadRequestException,
-  ConflictException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { CategoriesDTO } from './dto';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class CategoriesService {

--- a/src/categories/dto/categories.dto.ts
+++ b/src/categories/dto/categories.dto.ts
@@ -5,7 +5,7 @@ export class CategoriesDTO {
   @IsNotEmpty({ message: 'Nome é obrigatório' })
   name: string;
 
-  @IsBoolean({message: 'Habilitado debve ser do tipo boolean'})
+  @IsBoolean({message: 'Habilitado deve ser do tipo boolean'})
   @IsNotEmpty({ message: 'Habilitado é obrigatório' })
   enable: boolean;
 }

--- a/src/categories/dto/categories.dto.ts
+++ b/src/categories/dto/categories.dto.ts
@@ -5,7 +5,7 @@ export class CategoriesDTO {
   @IsNotEmpty({ message: 'Nome é obrigatório' })
   name: string;
 
-  @IsBoolean({message: 'Habilitado debe ser do tipo boolean'})
+  @IsBoolean({message: 'Habilitado debve ser do tipo boolean'})
   @IsNotEmpty({ message: 'Habilitado é obrigatório' })
   enable: boolean;
 }

--- a/src/categories/dto/categories.dto.ts
+++ b/src/categories/dto/categories.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+export class CategoriesDTO {
+  @IsString({ message: 'Nome deve ser do tipo string' })
+  @IsNotEmpty({ message: 'Nome é obrigatório' })
+  name: string;
+
+  @IsBoolean({message: 'Habilitado debe ser do tipo boolean'})
+  @IsNotEmpty({ message: 'Habilitado é obrigatório' })
+  enable: boolean;
+}

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -1,1 +1,0 @@
-export class CreateCategoryDto {}

--- a/src/categories/dto/index.ts
+++ b/src/categories/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './categories.dto';

--- a/src/categories/dto/update-category.dto.ts
+++ b/src/categories/dto/update-category.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateCategoryDto } from './create-category.dto';
-
-export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}


### PR DESCRIPTION
Nesta PR, implementei as funcionalidades necessárias para o cadastro, atualização, listagem de categorias. A rota POST `/api/categories` é responsável pelo cadastro, garantindo validações pelo nome para evitar duplicidades. A rota PUT `/api/categories/:uid` permite a atualização do nome e status de uma categoria. A rota GET `/api/categories/:uid` possibilita a consulta de categorias. Adicionei tratamentos de erros para garantir a integridade da aplicação.
